### PR TITLE
Fixed links to Github Barcelonajs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ BarcelonaJS
 
 ## How to submit a talk proposal
 
-1. [Create a new talk](https://github.com/barcelona-js/barcelonajs.org/issues/new?title=Your%20Awesome%20Talk&body=---%0Alevel:%20beginner%20%7C%20advanced%20%7C%20expert%0Alanguage:%20en%20%7C%20es%0Atwitter:%20YourTwitterHandle%0Atags:%0A%20%20-%20hello%0A%20%20-%20node%0A---%0A%0AYour%20awesome%20talk%20description)
+1. [Create a new talk](https://github.com/barcelonajs/barcelonajs.org/issues/new?title=Your%20Awesome%20Talk&body=---%0Alevel:%20beginner%20%7C%20advanced%20%7C%20expert%0Alanguage:%20en%20%7C%20es%0Atwitter:%20YourTwitterHandle%0Atags:%0A%20%20-%20hello%0A%20%20-%20node%0A---%0A%0AYour%20awesome%20talk%20description)
 2. fill out the title, your Twitter handle, the level and language of the talk and the description
 3. That's it. :)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Barcelona.JS is a usergroup focused on JavaScript and related topics. We meet regularly at the Mobile World Centre, C/ de Fontanella, 2 in Barcelona.",
   "license": "MIT",
   "version": "0.0.1",
-  "homepage": "https://github.com/barcelona-js/",
+  "homepage": "http://barcelonajs.org",
   "author": {
     "name": "Patrick Heneise",
     "url": "http://github.com/barcelonajs/"

--- a/templates/_footer.handlebars
+++ b/templates/_footer.handlebars
@@ -10,7 +10,7 @@
 				<a href="https://plus.google.com/communities/115705669406517039298" id="gplus" class="social-link"><i class="fa fa-google-plus-square fa-3x"></i></a>
 				<a href="https://vimeo.com/barcelonajs" id="vimeo" class="social-link"><i class="fa fa-vimeo-square fa-3x"></i></a>
 				<a href="http://www.flickr.com/groups/barcelonajs/" id="flickr" class="social-link"><i class="fa fa-flickr fa-3x"></i></a>
-				<a id="gh" href="https://github.com/barcelona-js" class="social-link"><i class="fa fa-github fa-3x"></i></a>
+				<a id="gh" href="https://github.com/barcelonajs" class="social-link"><i class="fa fa-github fa-3x"></i></a>
 				<!-- <h3>Sponsors</h3> -->
 			</section>
 			<section class="links">
@@ -29,7 +29,7 @@
 			<section class="footer-meta">
 				<h3>Meta</h3>
 				<p>Build with <i class="fa fa-heart"></i> in Barcelona. By Patrick Heneise and Jean-Carlos Menino</p>
-				<p>Hosted on GitHub Pages. See the code on <a href="https://github.com/barcelona-js/barcelonajs.org">Github.</a></p>
+				<p>Hosted on GitHub Pages. See the code on <a href="https://github.com/barcelonajs/barcelonajs.org">Github.</a></p>
 			</section>
 		</div>
 	</footer>


### PR DESCRIPTION
I've realised that Barcelona JS github organisation changed the name from hyphenated work to one word. This PR is to fix those links.

On the other hand, I've seen that waffle.io point to the old name (barcelona-js), however I've never used waffle.io therefore I don't exactly know if those links in README.md should be changed; if they have, let me know and I can add commit to this PR for it.